### PR TITLE
Track that majestic million includes the header

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -58,7 +58,8 @@
         "x9",
         "x10",
         "x11"
-      ]
+      ],
+      "includes_header": true
     },
     {
       "file": "suspicious_tlds.txt",


### PR DESCRIPTION
Noticed that that majestic_million.csv has a header but it's not tracked in the list manifest. Now it is, so that we know to remove it
```console
$ head *
==> majestic_million.csv <==
GlobalRank,TldRank,Domain,TLD,RefSubNets,RefIPs,IDN_Domain,IDN_TLD,PrevGlobalRank,PrevTldRank,PrevRefSubNets,PrevRefIPs
1,1,facebook.com,com,477861,2776509,facebook.com,com,1,1,477714,2775655
2,2,google.com,com,477844,2606872,google.com,com,2,2,477379,2605157
3,3,youtube.com,com,432847,2246021,youtube.com,com,3,3,432602,2245138
4,4,twitter.com,com,427738,2258851,twitter.com,com,4,4,427395,2258012
5,5,instagram.com,com,327854,1531349,instagram.com,com,5,5,327542,1530533
6,6,linkedin.com,com,324480,1389096,linkedin.com,com,6,6,324163,1388189
7,7,microsoft.com,com,314340,1175556,microsoft.com,com,7,7,313779,1173937
8,8,apple.com,com,286272,980518,apple.com,com,8,8,285796,980196
9,1,wikipedia.org,org,282812,1072571,wikipedia.org,org,9,1,282385,1072288
```