### PR TITLE
Add suspicious_subjects list to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -80,7 +80,7 @@
     {
       "file": "suspicious_subjects.txt",
       "identifier": "suspicious_subjects",
-      "display_name": "Suspicious subject phrases",
+      "display_name": "Suspicious subject phrases. Recommended usage: combine this with other signals, don't use on its own",
       "headers": [
         "entry"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,22 @@
       "includes_header": true
     },
     {
+      "file": "suspicious_context.txt",
+      "identifier": "suspicious_content",
+      "display_name": "Suspicious content phrases",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
+      "file": "suspicious_subjects.txt",
+      "identifier": "suspicious_subjects",
+      "display_name": "Suspicious subject phrases",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
       "file": "suspicious_tlds.txt",
       "identifier": "suspicious_tlds",
       "display_name": "Suspicious Top-Level Domains",

--- a/manifest.json
+++ b/manifest.json
@@ -78,14 +78,6 @@
       "includes_header": true
     },
     {
-      "file": "suspicious_context.txt",
-      "identifier": "suspicious_content",
-      "display_name": "Suspicious content phrases",
-      "headers": [
-        "entry"
-      ]
-    },
-    {
       "file": "suspicious_subjects.txt",
       "identifier": "suspicious_subjects",
       "display_name": "Suspicious subject phrases",

--- a/suspicious_content.txt
+++ b/suspicious_content.txt
@@ -1,60 +1,60 @@
- a secured file with you
- all parties completed
- all parties have completed
- all signers completed
- antivirus status
- but there was nobody who could sign
- clustered messages
- document has been completed
- download as excel
- dropbox file sent
- exceeded your
- file scanned by avast antivirus
- gift card 
- shared the following document
- help desk
- help-desk
- helpdesk
- how to resolve your email
- important task
- incoming fax
- incoming efax
- incoming e-fax
- kindly resend
- let me know
- new documents was sent to you
- new documents were sent to you
- new sign in
- new sign-in
- new signin
- no emails reply: no emails
- one drive team
- our courier attempted
- password reset
- purchase order
- scan result: clean
- secured files link
- security alert
- scanned against virus
- scanned for virus
- security message
- share a file
- shared a private document
- shared a secure file
- shared with you
- suspension
- suspicious activity
- suspicious login
- task completed
- to share some document
- unusual
- update your account
- used docu box to
- used docubox to
- verify your
- view click here
- view invoice in docxn
- will be deleted in a few hours
- will be deleted in few hours
- will be suspended
- you have new documents
+a secured file with you
+all parties completed
+all parties have completed
+all signers completed
+antivirus status
+but there was nobody who could sign
+clustered messages
+document has been completed
+download as excel
+dropbox file sent
+exceeded your
+file scanned by avast antivirus
+gift card 
+shared the following document
+help desk
+help-desk
+helpdesk
+how to resolve your email
+important task
+incoming fax
+incoming efax
+incoming e-fax
+kindly resend
+let me know
+new documents was sent to you
+new documents were sent to you
+new sign in
+new sign-in
+new signin
+no emails reply: no emails
+one drive team
+our courier attempted
+password reset
+purchase order
+scan result: clean
+secured files link
+security alert
+scanned against virus
+scanned for virus
+security message
+share a file
+shared a private document
+shared a secure file
+shared with you
+suspension
+suspicious activity
+suspicious login
+task completed
+to share some document
+unusual
+update your account
+used docu box to
+used docubox to
+verify your
+view click here
+view invoice in docxn
+will be deleted in a few hours
+will be deleted in few hours
+will be suspended
+you have new documents

--- a/suspicious_content.txt
+++ b/suspicious_content.txt
@@ -8,18 +8,18 @@ clustered messages
 document has been completed
 download as excel
 dropbox file sent
+encrypted document
 exceeded your
 file scanned by avast antivirus
 gift card 
-shared the following document
 help desk
 help-desk
 helpdesk
 how to resolve your email
 important task
-incoming fax
-incoming efax
 incoming e-fax
+incoming efax
+incoming fax
 kindly resend
 let me know
 new documents was sent to you
@@ -33,14 +33,15 @@ our courier attempted
 password reset
 purchase order
 scan result: clean
-secured files link
-security alert
 scanned against virus
 scanned for virus
+secured files link
+security alert
 security message
 share a file
 shared a private document
 shared a secure file
+shared the following document
 shared with you
 suspension
 suspicious activity
@@ -53,6 +54,7 @@ used docu box to
 used docubox to
 verify your
 view click here
+view document
 view invoice in docxn
 will be deleted in a few hours
 will be deleted in few hours

--- a/suspicious_subjects.txt
+++ b/suspicious_subjects.txt
@@ -60,7 +60,9 @@ pending invoice
 processed
 quick reply
 re: w-2
+remittance
 required
+required: completed docusign
 ringcentral
 scanned image
 secure message

--- a/suspicious_subjects.txt
+++ b/suspicious_subjects.txt
@@ -42,6 +42,7 @@ out of space
 password reset
 payment status
 pending invoice
+processed
 quick reply
 re: w-2
 required

--- a/suspicious_subjects.txt
+++ b/suspicious_subjects.txt
@@ -8,6 +8,7 @@ are you available
 attached file to docusign
 banking is temporarily unavailable
 bankofamerica
+bill for payment
 closing statement invoice
 completed: docusign
 de-activation of
@@ -23,6 +24,7 @@ docusign
 encrypted message
 encrypted secured
 efax
+expir
 failed delivery
 fedex tracking
 file was shared
@@ -31,10 +33,12 @@ fwd: due invoice paid
 has shared
 important information
 inbox is full
+infected
 invitation to comment
 invitation to edit
 invoice due
 left you a message
+low storage
 message from
 message received
 new evoice

--- a/suspicious_subjects.txt
+++ b/suspicious_subjects.txt
@@ -21,12 +21,15 @@ document has been sent to you via docusign
 document is ready for signature
 docusign
 encrypted message
+encrypted secured
+efax
 failed delivery
 fedex tracking
 file was shared
 freefax
 fwd: due invoice paid
 has shared
+important information
 inbox is full
 invitation to comment
 invitation to edit
@@ -35,30 +38,39 @@ left you a message
 message from
 message received
 new evoice
+new document
+new fax
+new file
 new message
+new sign-in
+new sign in
 new voicemail
 on desk
 out of space
+password maintenance
 password reset
+payment receipt
 payment status
+payroll disbursement
 pending invoice
 processed
 quick reply
 re: w-2
 required
-required: completed docusign
 ringcentral
 scanned image
+secure message
 secured files
 secured pdf 
 security alert
-new sign-in
-new sign in
+shared to you
 sign-in attempt
 sign in attempt
+statement of account
 staff review
 suspicious activity
 unrecognized login attempt
+unreleased message
 upgrade immediately
 urgent
 wants to share


### PR DESCRIPTION
Now that we have MQL namespaces, and specifically [strings.icontains](https://github.com/sublime-security/static-files/pull/25), we can finally use these Lists in MQL!

Example snippets:

suspicious_subjects:
```sql
type.inbound
and any($suspicious_subjects, strings.icontains(subject.subject, .))
```

Since our Regex functions require strings literals, we can't use the
suspicious_subjects_regex.txt list just yet. In a follow-up PR,
I think I'll add all of our regexes as strings in suspicious_subjects.txt so
we at least have some coverage.

Also in this PR, we remove an extra preceeding whitespace in one of our lists
so it'll be more effective in MQL.

-----

Deferred for later due to performance concerns:

suspicious_content:
```sql
type.inbound
and any($suspicious_content,
    strings.icontains(body.html.display_text, .) or
    strings.icontains(body.plain.raw, .)
)
```