### PR TITLE
Add Abuse[.]ch trusted reporter lists from URLhaus and MalwareBazaar

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
       ]
     },
     {
-      "url": "https://raw.githubusercontent.com/hugh-sublime/static-files/hugh.dev/disposable_email_providers.txt",
+      "url": "https://raw.githubusercontent.com/sublime-security/static-files/master/disposable_email_providers.txt",
       "file": "disposable_email_providers.txt",
       "identifier": "disposable_email_providers",
       "display_name": "Disposable (or Temporary) Email Providers",

--- a/manifest.json
+++ b/manifest.json
@@ -131,7 +131,7 @@
     {
       "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt",
       "identifier": "abuse_ch_malwarebazaar_sha256_trusted_reporters",
-      "display_name": "Abuse.ch: MalwareBazaar SHA256 hashes. Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT",
+      "display_name": "Abuse.ch: MalwareBazaar SHA256 hashes. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT",
       "headers": [
         "entry"
       ]
@@ -139,7 +139,7 @@
     {
       "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt",
       "identifier": "abuse_ch_urlhaus_urls_trusted_reporters",
-      "display_name": "Abuse.ch: URLhaus URLs. Trusted reporters: Cryptolaemus1, abuse_ch",
+      "display_name": "Abuse.ch: URLhaus URLs. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: Cryptolaemus1, abuse_ch",
       "headers": [
         "entry"
       ]
@@ -147,7 +147,7 @@
     {
       "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt",
       "identifier": "abuse_ch_urlhaus_domains_trusted_reporters",
-      "display_name": "Abuse.ch: URLhaus domains derived from trusted reporter URLs. Trusted reporters: Cryptolaemus1, abuse_ch",
+      "display_name": "Abuse.ch: URLhaus domains derived from trusted reporter URLs. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: Cryptolaemus1, abuse_ch",
       "headers": [
         "entry"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,50 +1,7 @@
 {
   "lists": [
     {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt",
-      "identifier": "abuse_ch_malwarebazaar_sha256_trusted_reporters",
-      "display_name": "Abuse.ch: MalwareBazaar [Last 90 days Unfiltered/Raw] Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT\"",
-      "headers": [
-        "entry"
-      ]
-    },
-    {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_trusted_reporters.csv",
-      "identifier": "abuse_ch_malwarebazaar_trusted_reporters",
-      "display_name": "Abuse.ch: MalwareBazaar [Last 90 days Unfiltered/Raw] Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT\"",
-      "headers": [
-        "x",
-        "entry"
-      ]
-    },
-    {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_trusted_reporters.csv",
-      "identifier": "abuse_ch_urlhaus_trusted_reporters",
-      "display_name": "Abuse.ch: URLhaus [Last 90 days Unfiltered/Raw] Trusted reporters: Cryptolaemus1, abuse_ch",
-      "headers": [
-        "x",
-        "x",
-        "entry"
-      ]
-    },
-    {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt",
-      "identifier": "abuse_ch_urlhaus_urls_trusted_reporters",
-      "display_name": "Abuse.ch: URLhaus [Last 90 days Unfiltered/Raw] Trusted reporters: Cryptolaemus1, abuse_ch",
-      "headers": [
-        "entry"
-      ]
-    },
-    {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt",
-      "identifier": "abuse_ch_urlhaus_domains_trusted_reporters",
-      "display_name": "Abuse.ch: URLhaus [Last 90 days Unfiltered/Raw] You should NOT use this list on its own - filtering is required. Trusted reporters: Cryptolaemus1, abuse_ch",
-      "headers": [
-        "entry"
-      ]
-    },
-    {
-      "url": "https://raw.githubusercontent.com/hugh-sublime/static-files/hugh.dev/alexa_top_1m.csv",
+      "file": "alexa_top_1m.csv",
       "identifier": "alexa_1m",
       "display_name": "Alexa Top 1 Million Domains",
       "headers": [
@@ -53,7 +10,6 @@
       ]
     },
     {
-      "url": "https://raw.githubusercontent.com/sublime-security/static-files/master/disposable_email_providers.txt",
       "file": "disposable_email_providers.txt",
       "identifier": "disposable_email_providers",
       "display_name": "Disposable (or Temporary) Email Providers",
@@ -168,6 +124,30 @@
       "file": "url_shorteners.txt",
       "identifier": "url_shorteners",
       "display_name": "URL Shorteners",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt",
+      "identifier": "abuse_ch_malwarebazaar_sha256_trusted_reporters",
+      "display_name": "Abuse.ch: MalwareBazaar SHA256 hashes. Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT\"",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt",
+      "identifier": "abuse_ch_urlhaus_urls_trusted_reporters",
+      "display_name": "Abuse.ch: URLhaus URLs. Trusted reporters: Cryptolaemus1, abuse_ch",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt",
+      "identifier": "abuse_ch_urlhaus_domains_trusted_reporters",
+      "display_name": "Abuse.ch: URLhaus domains derived from trusted reporter URLs. Trusted reporters: Cryptolaemus1, abuse_ch",
       "headers": [
         "entry"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -147,7 +147,7 @@
     {
       "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt",
       "identifier": "abuse_ch_urlhaus_domains_trusted_reporters",
-      "display_name": "Abuse.ch: URLhaus domains derived from trusted reporter URLs. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: Cryptolaemus1, abuse_ch",
+      "display_name": "Abuse.ch: Domains derived from $abuse_ch_urlhaus_urls_trusted_reporters. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: Cryptolaemus1, abuse_ch",
       "headers": [
         "entry"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -131,7 +131,7 @@
     {
       "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt",
       "identifier": "abuse_ch_malwarebazaar_sha256_trusted_reporters",
-      "display_name": "Abuse.ch: MalwareBazaar SHA256 hashes. Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT\"",
+      "display_name": "Abuse.ch: MalwareBazaar SHA256 hashes. Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT",
       "headers": [
         "entry"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "lists": [
     {
-      "file": "alexa_top_1m.csv",
+      "url": "https://raw.githubusercontent.com/hugh-sublime/static-files/hugh.dev/alexa_top_1m.csv",
       "identifier": "alexa_1m",
       "display_name": "Alexa Top 1 Million Domains",
       "headers": [
@@ -10,6 +10,7 @@
       ]
     },
     {
+      "url": "https://raw.githubusercontent.com/hugh-sublime/static-files/hugh.dev/disposable_email_providers.txt",
       "file": "disposable_email_providers.txt",
       "identifier": "disposable_email_providers",
       "display_name": "Disposable (or Temporary) Email Providers",

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,49 @@
 {
   "lists": [
     {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt",
+      "identifier": "abuse_ch_malwarebazaar_sha256_trusted_reporters",
+      "display_name": "Abuse.ch: MalwareBazaar [Last 90 days Unfiltered/Raw] Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT\"",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_trusted_reporters.csv",
+      "identifier": "abuse_ch_malwarebazaar_trusted_reporters",
+      "display_name": "Abuse.ch: MalwareBazaar [Last 90 days Unfiltered/Raw] Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT\"",
+      "headers": [
+        "x",
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_trusted_reporters.csv",
+      "identifier": "abuse_ch_urlhaus_trusted_reporters",
+      "display_name": "Abuse.ch: URLhaus [Last 90 days Unfiltered/Raw] Trusted reporters: Cryptolaemus1, abuse_ch",
+      "headers": [
+        "x",
+        "x",
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt",
+      "identifier": "abuse_ch_urlhaus_urls_trusted_reporters",
+      "display_name": "Abuse.ch: URLhaus [Last 90 days Unfiltered/Raw] Trusted reporters: Cryptolaemus1, abuse_ch",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt",
+      "identifier": "abuse_ch_urlhaus_domains_trusted_reporters",
+      "display_name": "Abuse.ch: URLhaus [Last 90 days Unfiltered/Raw] You should NOT use this list on its own - filtering is required. Trusted reporters: Cryptolaemus1, abuse_ch",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
       "url": "https://raw.githubusercontent.com/hugh-sublime/static-files/hugh.dev/alexa_top_1m.csv",
       "identifier": "alexa_1m",
       "display_name": "Alexa Top 1 Million Domains",


### PR DESCRIPTION
# Context

We now have a daily lambda that filters lists from Abuse[.]ch URLhaus and MalwareBazaar down to just the trusted providers (outlined in the display name). The newly added lists (available at `https://global-sublime-static-lists.s3.amazonaws.com/latest`):

* `abuse_ch_malwarebazaar_trusted_reporters.csv` (83.2 MB)
  * Filtered the MalwareBazaar CSV down to just the trusted reporters. This includes all the fields
* `abuse_ch_malwarebazaar_sha256_trusted_reporters.txt` (12.1 MB)
  * This is the `sha256_hash` column from `abuse_ch_malwarebazaar_trusted_reporters.csv`
* `abuse_ch_urlhaus_trusted_reporters.csv` (3.4 MB)
  * Filtered the URLhaus CSV down to just the trusted reporters. This includes all the fields
* `abuse_ch_urlhaus_urls_trusted_reporters.txt` (635.5 KB)
  * This is the `url` field from `abuse_ch_urlhaus_trusted_reporters.csv`
* `abuse_ch_urlhaus_domains_trusted_reporters.txt` (191.4 KB)
  * This is the `domain` part of the URLs from `abuse_ch_urlhaus_urls_trusted_reporters.txt`
  * Duplicates are removed

While we would be able to derive some of the lists from just the filtered CSV files, we probably want to avoid that since they are pretty large to download. We can work with the preprocessed lists for now and always change it to the larger CSVs for flexibility in the future.

In addition to the lists being written to `https://global-sublime-static-lists.s3.amazonaws.com/latest`, we also write the daily lists to a date folder as well. For example, `https://global-sublime-static-lists.s3.amazonaws.com/2023-05-18/`. We do this in case we want to "roll back" or pin to a previous list.

# Tests

I pointed my local instances to my fork's branch. Verified that the lists get imported and populated:

![Screenshot 2023-05-18 at 10 01 40 AM](https://github.com/sublime-security/static-files/assets/112737708/21d08188-d236-4ca1-922e-ace3d1c662e5)
![Screenshot 2023-05-18 at 10 01 48 AM](https://github.com/sublime-security/static-files/assets/112737708/f09c718b-a034-413e-a510-8ace88a0543b)
![Screenshot 2023-05-18 at 10 01 59 AM](https://github.com/sublime-security/static-files/assets/112737708/e6a40a4f-baf7-4156-a857-bf39f3c90f30)
![Screenshot 2023-05-18 at 10 02 16 AM](https://github.com/sublime-security/static-files/assets/112737708/10d9ca4a-ca2e-4327-8106-f57991cfac54)


I also tested out using the full CSVs (see commit 3f14ee7e3feab25ed93f27a56dcadca75ebd2ff0) and filtering down based on a column.