### PR TITLE
New List: file_flavors_macros.txt

### DIFF
--- a/file_flavors_macros.txt
+++ b/file_flavors_macros.txt
@@ -1,0 +1,12 @@
+application/vnd.ms-excel
+application/CDFV2
+application/vnd.openxmlformats-officedocument.wordprocessingml.document
+application/msword
+application/vnd.ms-word.document.macroEnabled.12
+application/vnd.openxmlformats-officedocument.wordprocessingml.document
+application/vnd.openxmlformats-officedocument.wordprocessingml.template
+application/vnd.ms-word.template.macroEnabled.12
+olecf_file
+ooxml_file
+mhtml_file
+wordml_file

--- a/manifest.json
+++ b/manifest.json
@@ -58,6 +58,14 @@
       ]
     },
     {
+       "file": "file_flavors_macros.txt",
+       "identifier": "file_flavors_macros",
+       "display_name": "File flavors of documents that can run macros",
+       "headers": [
+         "entry"
+       ]
+     },
+    {
       "file": "free_subdomain_hosts.txt",
       "identifier": "free_subdomain_hosts",
       "display_name": "Free Subdomain Hosts",


### PR DESCRIPTION
TL;DR: Right now, some macro detections rely on a file extension in order to detect a document, which misses macros inside extension-less files. Using flavors to find documents is more reliable and ensures that files are not missed.

---
Rule example:


Existing rule:
```
type.inbound
and any(attachments, 
  .file_extension in~ $file_extensions_macros
  and file.oletools(.).indicators.vba_macros.risk == "high"
```

Fixed rule:
```
type.inbound
and any(attachments, 
  (.file_extension in~ $file_extensions_macros or .content_type in~ $file_flavors_macros)
  and file.oletools(.).indicators.vba_macros.risk == "high"
```


--- 
File example:


Malicious .xls file with macros, but no file extension (file name: `test`): 
![image](https://github.com/sublime-security/static-files/assets/30846409/11248551-126e-4cde-a5f8-d48bddd47130)
https://analyzer.sublime.security?id=98d97d78-54f4-466d-a40c-1f1775fcf6d3


Same .xls file with macros, but _with_ file extension (file name: `test.xls`): 
![image](https://github.com/sublime-security/static-files/assets/30846409/58a07089-bd5e-4720-8d5a-5ff689547a50)
https://analyzer.sublime.security?id=d4fe2018-8789-49e4-a24e-305699bbe193