### PR TITLE
Add gzip support

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -129,7 +129,7 @@
       ]
     },
     {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt",
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt.gz",
       "identifier": "abuse_ch_malwarebazaar_sha256_trusted_reporters",
       "display_name": "Abuse.ch: MalwareBazaar SHA256 hashes. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: pr0xylife, abuse_ch, cocaman, James_inthe_box, JAMESWT_MHT",
       "headers": [
@@ -137,7 +137,7 @@
       ]
     },
     {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt",
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt.gz",
       "identifier": "abuse_ch_urlhaus_urls_trusted_reporters",
       "display_name": "Abuse.ch: URLhaus URLs. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: Cryptolaemus1, abuse_ch",
       "headers": [
@@ -145,7 +145,7 @@
       ]
     },
     {
-      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt",
+      "url": "https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt.gz",
       "identifier": "abuse_ch_urlhaus_domains_trusted_reporters",
       "display_name": "Abuse.ch: Domains derived from $abuse_ch_urlhaus_urls_trusted_reporters. Note: Entries are limited to the following trusted reporters, but are otherwise unfiltered. We recommend using filtering logic in MQL to reduce potential false positives. Trusted reporters: Cryptolaemus1, abuse_ch",
       "headers": [


### PR DESCRIPTION
# Context

Now that abuse[.]ch lists are being updated more frequently, we want to minimize the size of these lists when possible. I've added gzip support in Mantis with https://github.com/sublime-security/go-mantis/pull/3363 and tested that handles gzips properly.

We may want to hold off on merging this until folks pick up the latest Mantis changes.

Test output:

```
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List disposable_email_providers already up-to-date (etag=127dbe1391f98d06e7917f107daa864a428f312f61a105ef72b05786c78bfa65)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List alexa_1m already up-to-date (etag=e5c991397e2ee21aa346cc57aea9405c8c43b4c9ce32aaf6f647ebd9e0428af4)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List tranco_1m already up-to-date (etag=57c180996040fea2125a4440f7c965badc377d5bb934b21d0700b6510672d56d)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List suspicious_tlds already up-to-date (etag=60e7fcaed08264acb664f1a3fe2e87b115fb5acc387f4a18a8819fc1bf40749e)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List file_extensions_common_archives already up-to-date (etag=5127dd7d888a8709ffd3f78f1d6a106284ff0670d68baf09bad2159ac52a0863)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List file_extensions_executables already up-to-date (etag=49c051a11679b9c320b9c42a8dd4c4239ef94ace4757ce9257fda8b29cd641b0)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List free_email_providers already up-to-date (etag=23969ff16d960c21e477ed99df6d1a29516cd07c698391b6a3fa70abb97b3e9f)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List umbrella_1m already up-to-date (etag=51822f48b00aa03a7d21b47bcef0b486b59824ccdca57a576a4e78ec4f64914c)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List file_extensions_macros already up-to-date (etag=96aaf1e787af77261eae87c78ae61183949e664ab4689ad79fdff5b6036eb733)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List free_subdomain_hosts already up-to-date (etag=124e2220259f9911c1d7360cb65f507f0d6c24cd80f8056bfe5952f5554bb32b)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List umbrella_1m_tld already up-to-date (etag=ffb7bc1c3f23a0c713bd5405d48e0effe31db28112b9627535601848a95c46c7)
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:213 Downloading and extracting entries for abuse_ch_urlhaus_domains_trusted_reporters from CSV at https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_domains_trusted_reporters.txt.gz
2023-05-24T21:52:24-07:00 DEBUG static_files/list_sync.go:208 List majestic_million already up-to-date (etag=f9cec99a9b0001dc73b5fd6b2fe236819c5ecd71126f1db931ddb29bc2048acb)
2023-05-24T21:52:25-07:00 DEBUG static_files/list_sync.go:208 List url_shorteners already up-to-date (etag=471ba4f88f7dfbe043b03044ae250941797834481d3a34601f9289a84729ee53)
2023-05-24T21:52:25-07:00 DEBUG static_files/list_sync.go:208 List free_file_hosts already up-to-date (etag=6763a3a3f4dfbbebf944f9e6eb493fa98f18450275aeef771912aef9336f72b2)
2023-05-24T21:52:25-07:00 DEBUG static_files/list_sync.go:213 Downloading and extracting entries for abuse_ch_malwarebazaar_sha256_trusted_reporters from CSV at https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_malwarebazaar_sha256_trusted_reporters.txt.gz
2023-05-24T21:52:25-07:00 DEBUG static_files/list_sync.go:213 Downloading and extracting entries for abuse_ch_urlhaus_urls_trusted_reporters from CSV at https://global-sublime-static-lists.s3.amazonaws.com/latest/abuse_ch_urlhaus_urls_trusted_reporters.txt.gz
2023-05-24T21:52:25-07:00 INFO static_files/list_sync.go:229 Synchronizing entries in list abuse_ch_urlhaus_domains_trusted_reporters (etag=60e6b3f20fec6ad3b24815a6fd02e7f9, size=11548)
2023-05-24T21:52:25-07:00 INFO static_files/list_sync.go:229 Synchronizing entries in list abuse_ch_urlhaus_urls_trusted_reporters (etag=9a1a8c23a3bc4a087b18c8341bd274db, size=16187)
2023-05-24T21:52:26-07:00 INFO static_files/list_sync.go:229 Synchronizing entries in list abuse_ch_malwarebazaar_sha256_trusted_reporters (etag=52ac662c3904571d507843958f505cfd-2, size=196247)
```