### PR TITLE
Add $file_types_images list

### DIFF
--- a/file_types_images.txt
+++ b/file_types_images.txt
@@ -1,0 +1,11 @@
+bmp
+cr2
+gif
+heif
+ico
+jp2
+jpg
+jxr
+png
+tif
+webp

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,14 @@
       ]
     },
     {
+      "file": "file_types_images.txt",
+      "identifier": "file_types_images",
+      "display_name": "File types of images, not necessarily matching file extensions but used by checking a file signature",
+      "headers": [
+        "entry"
+      ]
+    },
+    {
       "file": "free_email_providers.txt",
       "identifier": "free_email_providers",
       "display_name": "Free Email Providers",


### PR DESCRIPTION
I took the `FileType` enum that we have and stripped it out to match images so that it can be used in rules to compare against `.file_type` on an extension.