### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -188,6 +188,7 @@ urbanoutfitters.com
 usbank.com
 usda.gov
 usps.gov
+verizon.com
 verizonwireless.com
 virtru.com
 vmware.com


### PR DESCRIPTION
Adding verizon.com. Verizon.net used to offer personal email addresses, but verizon.com communications are all company originated.