### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -22,6 +22,7 @@ bankofamerica.com
 barclays.com
 barracuda.com
 basecamp.com
+behance.com
 bestbuy.com
 bbc.com
 bill.com


### PR DESCRIPTION
The latest rank for behance.com is 46658
A division of adobe. 