### PR TITLE
add getfoureyes[.]com

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -46,6 +46,7 @@ firebasestorage.googleapis.com
 forms.office.com
 frame.io
 fromsmash.com
+getfoureyes.com
 gofile.io
 hightail.com
 idrive.com


### PR DESCRIPTION
observed in MS phishing used as a landing page to provide a link to the actual phishing page