### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -20,6 +20,7 @@ appfolio.com
 apple.com
 appomni.com
 ariba.com
+arkia.co.il
 army.mil
 arxiv.org
 asana.com


### PR DESCRIPTION
Adding arkia.co.il (Israeli airline) to high trust senders