### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -58,6 +58,7 @@ canva.com
 cardalert.com
 carta.com
 cbinsights.com
+cbsa-asfc.gc.ca
 cdc.gov
 chase.com
 checkpoint.com


### PR DESCRIPTION
Adding cbsa-asfc.gc.ca to high trust senders (Canada Border Services Agency)