### PR TITLE
add conga-sign.com to high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -75,6 +75,7 @@ cloudlabs.ai
 cloudlabsai.net
 coinbase.com
 concursolutions.com
+conga-sign.com
 connectyourcare.com
 costco.com
 coupahost.com


### PR DESCRIPTION
at first glance this seemed very odd, but it's legit. Appears to have some relationship to onespan's "e-signlive" as well 

References: 
- https://urlscan.io/search/#domain%3Aconga-sign.com
- https://conga.com/products/esignature/conga-sign
- https://www.onespan.com/partners/security/channel-partners/conga

sample: 
a4f9dff78724a88979a301d28efad02c765ccdeda6928224de4f3ff8a6080283