### PR TITLE
add gs.com to  high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -150,6 +150,7 @@ greenhouse.io
 greythr.com
 grid.is
 groupon.com
+gs.com
 hashicorp.com
 hdfcbank.com
 hellofax.com


### PR DESCRIPTION
gs.com = [goldman sachs](https://www.goldmansachs.com/)