### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -358,6 +358,7 @@ washingtonpost.com
 webforms.io
 webrootanywhere.com
 wellsfargo.com
+wellsfargorewards.com
 wikipedia.org
 workday.com
 works.com


### PR DESCRIPTION
Adding wellsfargorewards.com to high trust senders.