### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -299,6 +299,7 @@ service-now.com
 shop.app
 shopify.com
 signin.aws
+signnow.com
 signup.aws
 simplelegal.com
 sktelecom.com


### PR DESCRIPTION
Adding signnow.com to high trust senders