### PR TITLE
add ultipro.com to  high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -348,6 +348,7 @@ twitter.com
 uber.com
 ubs.com
 ukg.com
+ultipro.com
 united.com
 urbanoutfitters.com
 usaa.com


### PR DESCRIPTION
HR program related to ukg.com (already added)