### PR TITLE
add firefox.com to high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -132,6 +132,7 @@ fbi.gov
 fedex.com
 fidelity.com
 figma.com
+firefox.com
 firstam.com
 fiserv.com
 fishbowlapp.co


### PR DESCRIPTION
legit emails around firefox accounts (https://accounts.firefox.com/)