### PR TITLE
add mailhippo.com to  high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -200,6 +200,7 @@ lever.co
 linkedin.com
 lookermail.com
 mailchimp.com
+mailhippo.com
 malaysiaairlines.com
 manulife.com
 marriott.com


### PR DESCRIPTION
HIPAA compliant secure mail service