### PR TITLE
add emailconed.com to high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -132,6 +132,7 @@ echosign.com
 economist.com
 elastic.co
 email-loandepot.com
+emailconed.com
 emailrep.io
 empiresuite.com
 empforce.com


### PR DESCRIPTION
sedning domain for https://www.coned.com/en/
- a power company