### PR TITLE
add proxyvote.com to high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -313,6 +313,7 @@ politicopro.com
 powerapps.com
 primevideo.com
 principal.com
+proxyvote.com
 pwc.com
 q4inc.com
 qonto.com


### PR DESCRIPTION
used by several companies to manage share holder voting