### PR TITLE
add wfadvisors.com to high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -443,6 +443,7 @@ webrootanywhere.com
 wellsfargoadvisors.com
 wellsfargo.com
 wellsfargorewards.com
+wfadvisors.com
 wikipedia.org
 workday.com
 works.com


### PR DESCRIPTION
wells fargo owned domain