### PR TITLE
Adding sufybkt.com to free_subdomain_hosts.txt

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -92,6 +92,7 @@ stonly.com
 storage.cloud.google.com
 storage.googleapis.com
 solidfiles.com
+sufybkt.com
 sugarsync.com
 surveymonkey.com
 sway.office.com

--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -220,6 +220,7 @@ space.lc
 splashthat.com
 squarespace.com
 start.lc
+sufybkt.com
 te4m.de
 team.cx
 team.tl


### PR DESCRIPTION
sufybkt.com appears to be a blob storage bucketing solution: https://developer.sufy.com/storage-service/regions-and-endpoints