### PR TITLE
Update free_file_hosts.txt - add Figma

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -36,6 +36,7 @@ ecv.microsoft.com
 egnyte.com
 elephantdrive.com
 evernote.com
+figma.com
 filebin.net
 filedropper.com
 filefactory.com


### PR DESCRIPTION
Add Figma to list of free file hosts. Figma offers a free plan that can be used to deliver malicious links within Figma files.