### PR TITLE
Update free_subdomain_hosts.txt

### DIFF
--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -142,6 +142,7 @@ infos.lc
 inmotionhosting.com
 instawp.xyz
 int.ps
+infinityfree.com
 ir.tn
 it.gp
 jimdosite.com
@@ -158,6 +159,8 @@ m.vu
 ma.tn
 mobi.ps
 mp3.gp
+mockbin.org
+mocky.io
 musik.cx
 musik.lc
 my.vg
@@ -254,6 +257,7 @@ web.app
 web.gg
 webflow.io
 webcindario.com
+webhook.site
 website.tk
 weebly.com
 welt.tl


### PR DESCRIPTION
CISA referenced additional GRU favoured domains which include API level access, as well as some sub domain usage, specifically mocky/mockbin/webhook[.]site as mentioned here:

Splunk:
1. https://www.splunk.com/en_us/blog/security/mockbin-and-the-art-of-deception-tracing-adversaries-going-headless-and-mocking-apis.html

CISA: 

https://media.defense.gov/2025/May/21/2003719846/-1/-1/0/CSA_RUSSIAN_GRU_TARGET_LOGISTICS.PDF

There is additional coverage potential for Dynu & Pipedream, but Dynu is a dynamic DNS provider which also provides tiered access to include subdomains. (https://www.dynu.com/en-US)