### PR TITLE
CI: Pinning hash versions of latest actions used in repo

### DIFF
--- a/.github/workflows/update-and-process-tranco.yml
+++ b/.github/workflows/update-and-process-tranco.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
       

--- a/.github/workflows/update-majestic.yml
+++ b/.github/workflows/update-majestic.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
       

--- a/.github/workflows/update-umbrella.yml
+++ b/.github/workflows/update-umbrella.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
       

--- a/.github/workflows/validate-manifest.yml
+++ b/.github/workflows/validate-manifest.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
This is related to work [here](https://github.com/sublime-security/sublime-rules/pull/2505) and pins GitHub Actions to their latest version using their hash.