### PR TITLE
Update free_file_hosts to cover files.catbox.moe

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -55,6 +55,7 @@ files.com
 file.io
 filemail.com
 files.delivrto.me
+files.catbox.moe
 filetransfer.io
 firebasehostingproxy.page.link
 firebasestorage.googleapis.com

--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -23,6 +23,7 @@ bitbucket.com
 box.com
 buildin.ai
 canva.com
+catbox.moe
 cdn.discordapp.com
 cdn.fbsbx.com
 claude.site
@@ -77,6 +78,7 @@ kiwi6.com
 larksuite.com
 link.storjshare.io
 livedrive.com
+litterbox.catbox.moe
 mediafire.com
 mega.nz
 megafileupload.com


### PR DESCRIPTION
files.catbox.moe is routinely used to host malware, and other nefarious content

[Hunt](https://platform.sublime.security/messages/hunt?huntId=01975e6b-e9ff-741f-84c0-91e68c9ed854)