### PR TITLE
Update file_extensions_suspicious.txt

### DIFF
--- a/file_extensions_suspicious.txt
+++ b/file_extensions_suspicious.txt
@@ -36,6 +36,7 @@ hlp
 hpj
 hta
 htc
+hwp
 img
 inf
 ins


### PR DESCRIPTION
Both Google and Ahnsec report independently on the misuse of `.hwp` files. i previously suggesting adding it here as a suspicious extension, and 

Ahn: https://asec.ahnlab.com/en/88465/
Mandiant: https://cloud.google.com/blog/topics/threat-intelligence/north-korea-cyber-structure-alignment-2023

The preferred method of delivery is via this file format by some of the DPRK groups responsible for espionage. The file types themselves often rely on OLE file content, so the risk of erroneous files is minimal but still poses a historic risk as per the intelligence reporting. 

[Hunt-1 ](https://platform.sublime.security/messages/hunt?huntId=01978d3d-040d-7811-abe0-99ce839b4e7e)