### PR TITLE
Update free_file_hosts.txt

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -77,6 +77,7 @@ indd.adobe.com
 issuu.com
 jumpshare.com
 kiwi6.com
+krakenfiles.com
 larksuite.com
 limewire.com
 link.storjshare.io
@@ -118,6 +119,7 @@ storage.googleapis.com
 sufybkt.com
 sugarsync.com
 surveymonkey.com
+sync.com
 sway.cloud.microsoft
 sway.office.com
 tana.pub

--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -119,9 +119,9 @@ storage.googleapis.com
 sufybkt.com
 sugarsync.com
 surveymonkey.com
-sync.com
 sway.cloud.microsoft
 sway.office.com
+sync.com
 tana.pub
 telegra.ph
 teletype.in


### PR DESCRIPTION
Adding in two more free file hosts, krakenfiles[.]com (although blocked in some countries) is mostly used for bad and sync[.]com offers 5GB 'secure cloud storage'.