### PR TITLE
Update free_subdomain_hosts.txt

### DIFF
--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -159,6 +159,7 @@ l4n.contains_regexname.vg
 liebe.lc
 m.vu
 ma.tn
+mjt.lu
 mobi.ps
 mockbin.org
 mocky.io
@@ -166,7 +167,6 @@ mp3.gp
 musik.cx
 musik.lc
 my.vg
-mjt.lu
 mybluehost.me
 mybluemix.net
 myportfolio.com

--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -166,6 +166,7 @@ mp3.gp
 musik.cx
 musik.lc
 my.vg
+mjt.lu
 mybluehost.me
 mybluemix.net
 myportfolio.com


### PR DESCRIPTION
Mailjet dynamically generates subdomains under `mjt.lu` for each client or campaign, like:

`abc123.mjt.lu`

These subdomains identify the sender or the specific Mailjet client/account. They're not resellable like a public subdomain service would.