### PR TITLE
Update url_shorteners.txt

### DIFF
--- a/url_shorteners.txt
+++ b/url_shorteners.txt
@@ -139,6 +139,7 @@ migre.me
 minilien.com
 miniurl.com
 minurl.fr
+mjt.lu
 moourl.com
 myurl.in
 ne1.net


### PR DESCRIPTION
Each mjt.lu link acts as a:

Tracking redirect: It logs the click, then forwards to the final URL.

Click-through analytics tool: It tracks which recipient clicked the link in an email. 

IE: https://x6trn.mjt[.]lu/lnk/A1B2C3D4E5 => https://www[.]final-destination[.]com/page

[Hunt-1 ](https://platform.sublime.security/messages/hunt?huntId=0197f442-52ee-7e02-9b48-461368f81fe6)


I suspect this may catch some legitimate mailjet campaigns, too given its used for legit purposes too.  Does this constitute a ShortURL in the way a bit.ly one is? I