### PR TITLE
Remove xrho.com

### DIFF
--- a/free_email_providers.txt
+++ b/free_email_providers.txt
@@ -21750,7 +21750,6 @@ xploit.ml
 xpost.plala.or.jp
 xpressmail.zzn.com
 xprice.co
-xrho.com
 xrlihiuvt.shop
 xs4all.nl
 xsecurity.org


### PR DESCRIPTION
Not a disposable email domain

```
;; QUESTION SECTION:
;xrho.com.                      IN      MX

;; ANSWER SECTION:
xrho.com.               300     IN      MX      39 route1.mx.cloudflare.net.
xrho.com.               300     IN      MX      72 route3.mx.cloudflare.net.
xrho.com.               300     IN      MX      54 route2.mx.cloudflare.net.
```