### PR TITLE
Update free_file_hosts.txt

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -100,6 +100,7 @@ ncv.microsoft.com
 nethunt.com
 new.express.adobe.com
 notion.so
+0x0.st
 onedrive.live.com
 onenoteonlinesync.onenote.com
 padlet.com


### PR DESCRIPTION
Temp file hosting found abusing malware here https://0x0.st/ via: https://www.virustotal.com/gui/domain/0x0.st/relations