### PR TITLE
Update free_file_hosts.txt

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -103,6 +103,7 @@ new.express.adobe.com
 notion.so
 onedrive.live.com
 onenoteonlinesync.onenote.com
+onehub.one
 padlet.com
 pcloud.com
 pixeldrain.com
@@ -134,6 +135,7 @@ sync.com
 tana.pub
 telegra.ph
 teletype.in
+terabox.com
 temp.sh
 tinyupload.com
 transfer.sh


### PR DESCRIPTION
Added in two hosts abused by MuddyWater, Mango Sandstorm, and Static Kitten, AKA TA450.

[Source](https://www.proofpoint.com/uk/blog/threat-insight/security-brief-ta450-uses-embedded-links-pdf-attachments-latest-campaign)