### PR TITLE
Update free_subdomain_hosts.txt

### DIFF
--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -122,6 +122,7 @@ gaming.lc
 github.io
 glide.in
 glitch.me
+ghost.io
 godaddysites.com
 googleusercontent.com
 gr.tn


### PR DESCRIPTION
Ghost.org offers hosting and it appears their subdomain offering looks like domain.ghost.io

https://ghost.org/help/change-ghost-io-subdomain/

https://www.virustotal.com/gui/domain/ghost.io/relations