### PR TITLE
Update suspicious_tlds.txt

### DIFF
--- a/suspicious_tlds.txt
+++ b/suspicious_tlds.txt
@@ -54,6 +54,7 @@ life
 link
 live
 loan
+lol
 ltd
 ly
 me


### PR DESCRIPTION
Adding in the `.lol` tld abused by APT43 as mentioned in the following report with the College/University spood credential phishing pages.

https://services.google.com/fh/files/misc/apt43-report-en.pdf