### PR TITLE
Update free_file_hosts.txt

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -142,6 +142,7 @@ terabox.com
 tinyupload.com
 transfer.sh
 transfernow.net
+transferxl.com
 ufile.io
 uploaded.net
 uploadfiles.io


### PR DESCRIPTION
Some abuse of free file sharing services mentioned here:

1. https://blog.google/threat-analysis-group/exposing-initial-access-broker-taies-conti/
2. https://attack.mitre.org/groups/G1011/

Human-Operated Phishing at scale evidence here adds in some confidence to the inclusion of both of these services. However, the misuse at this point is now 3 years ago, something to consider is the `timing out` of abused services when adding them.