### PR TITLE
Update suspicious_tlds.txt

### DIFF
--- a/suspicious_tlds.txt
+++ b/suspicious_tlds.txt
@@ -70,10 +70,10 @@ nom.za
 online
 ooo
 party
-press
 photos
 pictures
 pizza
+press
 pro
 pub
 pw

--- a/suspicious_tlds.txt
+++ b/suspicious_tlds.txt
@@ -70,6 +70,7 @@ nom.za
 online
 ooo
 party
+press
 photos
 pictures
 pizza


### PR DESCRIPTION
`.press` was abused by APT42 and their ongoing operations intersect with several publicly reported threat actor designations, including `CALANQUE` (Google Threat Analysis Group), `Charming Kitten` (ClearSky and CERTFA), `Mint Sandstorm/Phosphorus` (Microsoft), `TA453` (Proofpoint), `Yellow Garuda` (PwC), and `ITG18` (IBM X-Force).

https://cloud.google.com/blog/topics/threat-intelligence/untangling-iran-apt42-operations

I'm conscious of the use of this domain may lead to some confusion about the malicious nature of the tld, but for now i am happy to ensure it's suspicious nature is captured here.