### PR TITLE
Adding shutterstock.com to high trust

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -1,4 +1,3 @@
-shutterstock.com
 1password.com
 aarp.org
 acronis.com
@@ -410,6 +409,7 @@ sfax.com
 sharp.com
 shop.app
 shopify.com
+shutterstock.com
 signin.aws
 signnow.com
 signup.aws


### PR DESCRIPTION
Similar to Adobe, legitimate media company.

https://www.whois.com/whois/shutterstock.com

Related FP:
efb2f3d752654dfa2f0da8a0fc278d3592a608fca53a89e540b5376e86abdd9e


