### PR TITLE
Update url_shorteners.txt

### DIFF
--- a/url_shorteners.txt
+++ b/url_shorteners.txt
@@ -102,8 +102,8 @@ hurl.ws
 icanhaz.com
 idek.net
 inreply.to
-is.gd
 ionos.ly
+is.gd
 iscool.net
 iterasi.net
 jijr.com


### PR DESCRIPTION
ionos (a UK hosting provider( have a url shortener service used by them to redirect to FB and YT, https://platform.sublime.security/messages/4f5bc1a4b4012a61e3d2491869dfa966414f909c70fdfb7eb88187fe5b9301f5?preview_id=0198adb8-06d0-7bda-bb89-c9b26fdfd806

would benefit from some oversight here, but it looks like they provide it for themselves, i don't see it advertised anywhere on their site. https://www.ionos.com/