### PR TITLE
add uschovna.cz domains to free_file_hosts.txt

### DIFF
--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -1,3 +1,5 @@
+sendelephant.com
+uschovna.cz
 0x0.st
 1drv.com
 1drv.ms

--- a/free_file_hosts.txt
+++ b/free_file_hosts.txt
@@ -1,5 +1,3 @@
-sendelephant.com
-uschovna.cz
 0x0.st
 1drv.com
 1drv.ms
@@ -122,6 +120,7 @@ riddle.com
 sabercathost.com
 scribd.com
 send-anywhere.com
+sendelephant.com
 sendgb.com
 sendspace.com
 share.hsforms.com
@@ -153,6 +152,7 @@ ufile.io
 uploaded.net
 uploadfiles.io
 uplooder.net
+uschovna.cz
 view.genially.com
 view.storydoc.com
 viewer.joomag.com


### PR DESCRIPTION
uschovna.cz and sendelaphant.com, both owned by uschovna.cz