### PR TITLE
Update free_subdomain_hosts.txt

### DIFF
--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -196,6 +196,7 @@ onrender.com
 oraclecloud.com
 pagecloud.com
 pages.dev
+papershift.com
 party.lc
 pc.lc
 ph.tn
@@ -204,7 +205,6 @@ phplist.com
 pk.tn
 pl.tn
 planet.tl
-papershift.com
 portal.lc
 privat.lc
 pro.ac


### PR DESCRIPTION
Papershift.com is a HR system which... "Plan shifts, track working hours, manage vacation days and process payroll – all with one cloud-based software" they offer some subdomain as part of their URLs:

Sample: https://analyzer.sublime.security/?id=01997581-4f04-7d24-b604-c10f56d139d9

Similar Pattern-Based Subdomains Found:
•  o1.ptr2897.papershift.com - Uses a pattern with letters and numbers
•  status2.papershift.com - Has a number suffix, but the following (as does this, all appear legit)

All Discovered Subdomains: I found 42 total subdomains under papershift.com, including:
•  landing.papershift.com
•  web.papershift.com  
•  developers.papershift.com
•  app.papershift.com
•  api.papershift.com
•  cdn.papershift.com
•  And many others for staging, testing, and various services


1. url6494.papershift.com appears to be the primary (or only) subdomain following the exact url####.papershift.com pattern
2. I tested ranges around 6494 (6480-6510) and other common ranges but found no additional url#### subdomains
3. The domain resolves but serves a 404 error, suggesting it may be used for tracking, redirects, or inactive content
4. Papershift uses Cloudflare for DNS and hosting infrastructure

