### PR TITLE
Add citibanamex.com to high trust

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -1,3 +1,4 @@
+citibanamex.com
 1password.com
 aarp.org
 acronis.com


### PR DESCRIPTION
Domain owned by Citi bank, seen in sample 4f83a3974ed3273da911c7f8b4c104c2820dad85f253b8fd90d831151df10899
https://who.is/whois/citibanamex.com