### PR TITLE
Remove bolt.com and bolt.net from free email providers list

### DIFF
--- a/free_email_providers.txt
+++ b/free_email_providers.txt
@@ -3726,8 +3726,6 @@ bolero.plala.or.jp
 bollo.cz
 bollywoodz.com
 bolshie.co.uk
-bolt.com
-bolt.net
 boltonfans.com
 bombdiggity.com
 bombsquad.com


### PR DESCRIPTION
Removed 'bolt.com' and 'bolt.net' from the list of free email providers. These are now financial service companies.