### PR TITLE
Update high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -42,6 +42,7 @@ auth0.com
 authentisign.com
 aws.training
 axios.com
+ba.com
 bakermckenzie.com
 bankofamerica.com
 barclays.com
@@ -78,6 +79,7 @@ boldsign.com
 booking.com
 box.com
 brex.com
+britishairways.com
 bynder.com
 byspotify.com
 ca.gov


### PR DESCRIPTION
adding ba.com and britishairways.com to high trust sender domains