### PR TITLE
Add espn.com to high trust sender root domains

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -177,6 +177,7 @@ equifax.com
 esignatures.com
 esignlive.com
 esp-portal.com
+espn.com
 etsy.com
 eventbrite.com
 evernote.com


### PR DESCRIPTION
Adding to negate FP's across multiple rules, spawned from sus e-sign rule scoping. Fixed Amazon, Disney & possibly others not observed over L365D.

[- Sample 1](https://platform.sublime.security/messages/5035bae8b48e5828ca9daab709522bfeb1ce01e89596b5dbe9c8add0cdea1b3a?preview_id=019d1b21-d69e-7753-81fc-851bfb6e4442)

[- Hunt](https://platform.sublime.security/messages/hunt?huntId=019d77f1-285f-73ba-afbb-3e043a07051a)
[- Multi-hunt](https://hunt.limeseed.email/hunts/d0e60af5-22de-478e-8b01-15ffa94bebfc)
