### PR TITLE
Add 2 new domains to high trust sender list

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -41,6 +41,8 @@ atriushealth.org
 att-mail.com
 auth0.com
 authentisign.com
+autodesk.com
+autodeskcommunications.com
 aws.training
 axa.es
 axios.com


### PR DESCRIPTION
autodesk.com & autodeskcommunications.com.

Observing FP's in a handful of rules, mainly suspicious e-sign & cred theft rules, extending to password reset & others. No malice present on either domain that passed auth.

[- Multi-hunt (L365D)](https://hunt.limeseed.email/hunts/104d1d2f-4735-44a6-a11a-2b8cb3393738)
[- Platform FP's (L90D)](https://platform.sublime.security/messages/hunt?huntId=019d8841-ebb3-770d-bc8f-ed6c249aae5b)