### PR TITLE
Add fedexfreight.com to high trust sender domains

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -198,6 +198,7 @@ fastcompany.com
 fbi.gov
 federatedinsurance.com
 fedex.com
+fedexfreight.com
 fedins.com
 fidelity.com
 figma.com


### PR DESCRIPTION
Adding domain to this list since we were notified by a detection runner that this a legit domain associated with `fedex.com`.

Reference: https://github.com/sublime-security/sublime-rules/pull/4468