### PR TITLE
Add 'html.cafe' to the domain list

### DIFF
--- a/self_service_creation_platform_domains.txt
+++ b/self_service_creation_platform_domains.txt
@@ -72,6 +72,7 @@ glide.page
 gooey.ai
 heightsplatform.com
 heyflow.site
+html.cafe
 intakeq.com
 ipfs.dweb.link
 ipfs.io


### PR DESCRIPTION
adding html.cafe to self service creation platforms

HTML editor/hosting site. observed phishing pages hosted on this domain