### PR TITLE
Update free_subdomain_hosts.txt

### DIFF
--- a/free_subdomain_hosts.txt
+++ b/free_subdomain_hosts.txt
@@ -68,6 +68,7 @@ com.nu
 community.lc
 cool.hn
 cool.lc
+creatium.site
 creatorlink.net
 cs-clan.org
 csb.app


### PR DESCRIPTION
This is a Russian site that is similar to Wix. [Hunt](https://platform.sublime.security/hunts/019eb7e8-1559-7786-ab19-18702a0ea5ef) containing creatium.site.