### PR TITLE
add banamex.com to high_trust_sender_root_domains.txt

### DIFF
--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -49,6 +49,7 @@ aws.training
 axa.es
 axios.com
 ba.com
+banamex.com
 bakermckenzie.com
 bankofamerica.com
 barclays.com

--- a/high_trust_sender_root_domains.txt
+++ b/high_trust_sender_root_domains.txt
@@ -49,8 +49,8 @@ aws.training
 axa.es
 axios.com
 ba.com
-banamex.com
 bakermckenzie.com
+banamex.com
 bankofamerica.com
 barclays.com
 barclayscorp.com


### PR DESCRIPTION
common FP on spamhaus due to citigroup domain - https://platform.sublime.security/messages/50cb3c32fa1e0c45222d6b5dece52583b12923a9abdc90772cbcca58e86e3f88?preview_id=01a0160b-9fca-7a03-be3c-a8c269343c2a